### PR TITLE
make dhcpdSnmpPoolTable a net-snmp standard compliant table

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -78,12 +78,12 @@ The script should return three lines: the OID, "integer", and the
 number of configured pools.
 
   get
-  .1.3.6.1.4.1.21695.1.2.2.2.1
+  .1.3.6.1.4.1.21695.1.2.2.1.2.1
 
 OID, "string", and the name of your first address pool.
 
   get
-  .1.3.6.1.4.1.21695.1.2.2.4.1
+  .1.3.6.1.4.1.21695.1.2.2.1.4.1
 
 OID, "integer", and the number of active leases.
 
@@ -94,11 +94,11 @@ Quit the dialog using CTRL-D.
 The script returns the following variables:
 
   .1.3.6.1.4.1.21695.1.2.1: number of configured pools
-  .1.3.6.1.4.1.21695.1.2.2.<pool>: pool description
-  .1.3.6.1.4.1.21695.1.2.3.<pool>: size of the pool (number of addresses)
-  .1.3.6.1.4.1.21695.1.2.4.<pool>: active leases
-  .1.3.6.1.4.1.21695.1.2.5.<pool>: expired leases
-  .1.3.6.1.4.1.21695.1.2.6.<pool>: available addresses (size - active leases)
+  .1.3.6.1.4.1.21695.1.2.2.1.<pool>: pool description
+  .1.3.6.1.4.1.21695.1.2.3.1.<pool>: size of the pool (number of addresses)
+  .1.3.6.1.4.1.21695.1.2.4.1.<pool>: active leases
+  .1.3.6.1.4.1.21695.1.2.5.1.<pool>: expired leases
+  .1.3.6.1.4.1.21695.1.2.6.1.<pool>: available addresses (size - active leases)
 
 For a complete MIB file see the C<mibs> directory in the source archive.
 

--- a/cacti/snmp_queries/dhcp_snmp_leases.xml
+++ b/cacti/snmp_queries/dhcp_snmp_leases.xml
@@ -11,42 +11,42 @@
 			<method>walk</method>
 			<source>value</source>
 			<direction>input</direction>
-			<oid>.1.3.6.1.4.1.21695.1.2.2.1</oid>
+			<oid>.1.3.6.1.4.1.21695.1.2.2.1.1</oid>
 		</subnetIndex>
 		<subnetDesc>
 			<name>Description</name>
 			<method>walk</method>
 			<source>value</source>
 			<direction>input</direction>
-			<oid>.1.3.6.1.4.1.21695.1.2.2.2</oid>
+			<oid>.1.3.6.1.4.1.21695.1.2.2.1.2</oid>
 		</subnetDesc>
 		<subnetTotal>
 			<name>Total Size</name>
 			<method>walk</method>
 			<source>value</source>
 			<direction>output</direction>
-			<oid>.1.3.6.1.4.1.21695.1.2.2.3</oid>
+			<oid>.1.3.6.1.4.1.21695.1.2.2.1.3</oid>
 		</subnetTotal>
 		<subnetActive>
 			<name>Active Leases</name>
 			<method>walk</method>
 			<source>value</source>
 			<direction>output</direction>
-			<oid>.1.3.6.1.4.1.21695.1.2.2.4</oid>
+			<oid>.1.3.6.1.4.1.21695.1.2.2.1.4</oid>
 		</subnetActive>
 		<subnetExpired>
 			<name>Expired Leases</name>
 			<method>walk</method>
 			<source>value</source>
 			<direction>output</direction>
-			<oid>.1.3.6.1.4.1.21695.1.2.2.5</oid>
+			<oid>.1.3.6.1.4.1.21695.1.2.2.1.5</oid>
 		</subnetExpired>
 		<subnetAvailable>
 			<name>Available Leases</name>
 			<method>walk</method>
 			<source>value</source>
 			<direction>output</direction>
-			<oid>.1.3.6.1.4.1.21695.1.2.2.6</oid>
+			<oid>.1.3.6.1.4.1.21695.1.2.2.1.6</oid>
 		</subnetAvailable>
 	</fields>
 </dhcp_leases>

--- a/dhcpd-snmp
+++ b/dhcpd-snmp
@@ -225,16 +225,16 @@ sub create_dhcp_mib
 
     my $pool = $conf->{pools}->{$i};
     
-    $MIB{"2.1.".$i} = [ "integer", $i, 0 ];
-    $MIB{"2.2.".$i} = [ "string", $pool->{name}, 0 ];
-    $MIB{"2.3.".$i} = [ "integer", $pool->{total}, 0 ];
-    $MIB{"2.4.".$i} = [ "integer", 0, 0 ];
-    $MIB{"2.5.".$i} = [ "integer", 0, 0 ];
-    $MIB{"2.6.".$i} = [ "integer", 0, 0 ];
+    $MIB{"2.1.1.".$i} = [ "integer", $i, 0 ];
+    $MIB{"2.1.2.".$i} = [ "string", $pool->{name}, 0 ];
+    $MIB{"2.1.3.".$i} = [ "integer", $pool->{total}, 0 ];
+    $MIB{"2.1.4.".$i} = [ "integer", 0, 0 ];
+    $MIB{"2.1.5.".$i} = [ "integer", 0, 0 ];
+    $MIB{"2.1.6.".$i} = [ "integer", 0, 0 ];
 
-    $MIB_VALUES{"2.4.$i"} = 0;
-    $MIB_VALUES{"2.5.$i"} = 0;
-    $MIB_VALUES{"2.6.$i"} = 0;
+    $MIB_VALUES{"2.1.4.$i"} = 0;
+    $MIB_VALUES{"2.1.5.$i"} = 0;
+    $MIB_VALUES{"2.1.6.$i"} = 0;
   }
 
   @MIB_INDEX = sort { oidcmp($a, $b) } keys %MIB;
@@ -441,9 +441,9 @@ sub worker_thread
     foreach my $i (keys %{ $conf->{pools} }) {
       my $pool = $conf->{pools}->{$i};
       
-      $MIB_VALUES{"2.4.$i"} = $pool->{active};
-      $MIB_VALUES{"2.5.$i"} = $pool->{expired};
-      $MIB_VALUES{"2.6.$i"} = $pool->{total} - $pool->{active};
+      $MIB_VALUES{"2.1.4.$i"} = $pool->{active};
+      $MIB_VALUES{"2.1.5.$i"} = $pool->{expired};
+      $MIB_VALUES{"2.1.6.$i"} = $pool->{total} - $pool->{active};
     }
    
     sleep($cache_secs);
@@ -532,12 +532,12 @@ The script should return three lines: the OID, "integer", and the
 number of configured pools.
 
   get
-  .1.3.6.1.4.1.21695.1.2.2.2.1
+  .1.3.6.1.4.1.21695.1.2.2.1.2.1
 
 OID, "string", and the name of your first address pool.
 
   get
-  .1.3.6.1.4.1.21695.1.2.2.4.1
+  .1.3.6.1.4.1.21695.1.2.2.1.4.1
 
 OID, "integer", and the number of active leases.
 
@@ -548,11 +548,11 @@ Quit the dialog using CTRL-D.
 The script returns the following variables:
 
   .1.3.6.1.4.1.21695.1.2.1: number of configured pools
-  .1.3.6.1.4.1.21695.1.2.2.<pool>: pool description
-  .1.3.6.1.4.1.21695.1.2.3.<pool>: size of the pool (number of addresses)
-  .1.3.6.1.4.1.21695.1.2.4.<pool>: active leases
-  .1.3.6.1.4.1.21695.1.2.5.<pool>: expired leases
-  .1.3.6.1.4.1.21695.1.2.6.<pool>: available addresses (size - active leases)
+  .1.3.6.1.4.1.21695.1.2.2.1.2.<pool>: pool description
+  .1.3.6.1.4.1.21695.1.2.2.1.3.<pool>: size of the pool (number of addresses)
+  .1.3.6.1.4.1.21695.1.2.2.1.4.<pool>: active leases
+  .1.3.6.1.4.1.21695.1.2.2.1.5.<pool>: expired leases
+  .1.3.6.1.4.1.21695.1.2.2.1.6.<pool>: available addresses (size - active leases)
 
 For a complete MIB file see the C<mibs> directory in the source archive.
 

--- a/mibs/nettrack-dhcpd-snmp.mib
+++ b/mibs/nettrack-dhcpd-snmp.mib
@@ -55,6 +55,15 @@ dhcpdSnmpPoolTable OBJECT-TYPE
 		 address pool."
 	::= { dhcpdSnmp 2 }
 
+dhcpdSnmpPoolEntry OBJECT-TYPE
+    SYNTAX      DhcpdSnmpPoolEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+	"A row describing a given dhcp pool"
+    INDEX   { dhcpdSnmpPoolIndex }
+    ::= {dhcpdSnmpPoolTable 1 }
+
 DhcpdSnmpPoolEntry ::= SEQUENCE {
 dhcpdSnmpPoolIndex		Integer32,
 dhcpdSnmpPoolDescription	DisplayString,
@@ -70,7 +79,7 @@ dhcpdSnmpPoolIndex OBJECT-TYPE
 	STATUS		current
 	DESCRIPTION
 		"The index for each address pool."
-	::= { dhcpdSnmpPoolTable 1 }
+	::= { dhcpdSnmpPoolEntry 1 }
 
 dhcpdSnmpPoolDescription OBJECT-TYPE
 	SYNTAX		DisplayString
@@ -78,7 +87,7 @@ dhcpdSnmpPoolDescription OBJECT-TYPE
 	STATUS		current
 	DESCRIPTION
 		"Holds a textual description of the current pool."
-	::= { dhcpdSnmpPoolTable 2 }
+	::= { dhcpdSnmpPoolEntry 2 }
 
 dhcpdSnmpPoolSize OBJECT-TYPE
 	SYNTAX		Integer32
@@ -86,7 +95,7 @@ dhcpdSnmpPoolSize OBJECT-TYPE
 	STATUS		current
 	DESCRIPTION
 		"Number of addresses in the pool."
-	::= { dhcpdSnmpPoolTable 3 }
+	::= { dhcpdSnmpPoolEntry 3 }
 
 dhcpdSnmpPoolActiveLeases OBJECT-TYPE
 	SYNTAX		Integer32
@@ -94,7 +103,7 @@ dhcpdSnmpPoolActiveLeases OBJECT-TYPE
 	STATUS		current
 	DESCRIPTION
 		"Active leases."
-	::= { dhcpdSnmpPoolTable 4 }
+	::= { dhcpdSnmpPoolEntry 4 }
 
 dhcpdSnmpPoolExpiredLeases OBJECT-TYPE
 	SYNTAX		Integer32
@@ -102,7 +111,7 @@ dhcpdSnmpPoolExpiredLeases OBJECT-TYPE
 	STATUS		current
 	DESCRIPTION
 		"Expired leases."
-	::= { dhcpdSnmpPoolTable 5 }
+	::= { dhcpdSnmpPoolEntry 5 }
 
 dhcpdSnmpPoolAvailableAddresses OBJECT-TYPE
 	SYNTAX		Integer32
@@ -110,6 +119,6 @@ dhcpdSnmpPoolAvailableAddresses OBJECT-TYPE
 	STATUS		current
 	DESCRIPTION
 		"Available addresses."
-	::= { dhcpdSnmpPoolTable 6 }
+	::= { dhcpdSnmpPoolEntry 6 }
 
 END


### PR DESCRIPTION
Using the ``snmptable`` commands fails cause the mib is not compliant with normal net-snmp tables.

```
$ snmptable -c public ns1 NETTRACK-DHCPD-SNMP-MIB::dhcpdSnmpPoolTable
Was that a table? NETTRACK-DHCPD-SNMP-MIB::dhcpdSnmpPoolTable
```

After fixing the mib and extension it looks like:

```
$ snmptable -c public ns1 NETTRACK-DHCPD-SNMP-MIB::dhcpdSnmpPoolTable
SNMP table: NETTRACK-DHCPD-SNMP-MIB::dhcpdSnmpPoolTable

 dhcpdSnmpPoolIndex dhcpdSnmpPoolDescription dhcpdSnmpPoolSize dhcpdSnmpPoolActiveLeases dhcpdSnmpPoolExpiredLeases dhcpdSnmpPoolAvailableAddresses
                  1              "WLAN Gast"              2023                         0                       1180                            2023
                  2              "WLAN Orga"               245                         0                        167                             245
                  3              "WLAN Anki"               245                         0                        180                             245
                  4              "Spielfeld"              1640                         0                          0                            1640
                  5              "Westblock"               615                         0                        268                             615
                  6               "Ostblock"               615                         0                          0                             615
                  7          "Nordtribuehne"              1230                         0                        127                            1230
                  8           "Nordoberrang"              1025                         0                          0                            1025
                  9            "Trainerbank"               410                         0                          0                             410
                 11          "Spielfeld A-B"               205                         0                        118                             205
                 12          "Spielfeld C-D"               205                         0                        124                             205
                 13          "Spielfeld E-F"               205                         0                        131                             205
                 14          "Spielfeld G-H"               205                         0                        134                             205
                 15          "Spielfeld I-J"               205                         0                        123                             205
                 16          "Spielfeld K-L"               205                         0                        137                             205
                 17          "Spielfeld M-N"               205                         0                        139                             205
                 18          "Spielfeld O-P"               205                         0                        117                             205
                 21       "Trainerbank Heim"               205                         0                        119                             205
                 22            "Westblock A"               205                         0                        112                             205
                 23          "Westblock B-C"               205                         0                          0                             205
                 24          "Westblock D-E"               205                         0                          0                             205
                 25           "Ostblock A-B"               205                         0                        125                             205
                 26           "Ostblock C-D"               205                         0                        123                             205
                 27           "Ostblock E-F"               205                         0                        130                             205
                 28       "Trainerbank Gast"               205                         0                        114                             205
                 31      "Nordtribuehne A-B"               205                         0                        127                             205
                 32   "Nordtribuehne C-D(1)"               205                         0                        119                             205
                 33   "Nordtribuehne C-D(2)"               205                         0                        205                             205
                 34   "Nordtribuehne E-F(1)"               205                         0                          0                             205
                 35   "Nordtribuehne E-F(2)"               205                         0                        119                             205
                 36      "Nordtribuehne G-H"               205                         0                        130                             205
                 41      "Nord-Oberrang A-B"               205                         0                        127                             205
                 42      "Nord-Oberrang C-D"               205                         0                        132                             205
                 43      "Nord-Oberrang E-F"               205                         0                        140                             205
                 44      "Nord-Oberrang G-H"               205                         0                        144                             205
                 45      "Nord-Oberrang I-J"               205                         0                        131                             205
                 69                   "Team"               254                         0                        151                             254
```

ATTENTION: This change breaks existing setups where dhcpd-snmp is already in use but it makes it more compliant with other snmp pollers where you just say which table you want to poll and collect.